### PR TITLE
Add SatelliteCount method to Observation interface

### DIFF
--- a/rtcm3/glonass.go
+++ b/rtcm3/glonass.go
@@ -40,6 +40,10 @@ func (msg Message1009) Time() time.Time {
 	return DF034(msg.Epoch, time.Now().UTC())
 }
 
+func (msg Message1009) SatelliteCount() int {
+	return len(msg.SignalData)
+}
+
 // Extended L1-Only GLONASS RTK Observables
 type Message1010 struct {
 	AbstractMessage
@@ -73,6 +77,10 @@ func (msg Message1010) Serialize() []byte {
 
 func (msg Message1010) Time() time.Time {
 	return DF034(msg.Epoch, time.Now().UTC())
+}
+
+func (msg Message1010) SatelliteCount() int {
+	return len(msg.SignalData)
 }
 
 // L1&L2 GLONASS RTK Observables
@@ -110,6 +118,10 @@ func (msg Message1011) Serialize() []byte {
 
 func (msg Message1011) Time() time.Time {
 	return DF034(msg.Epoch, time.Now().UTC())
+}
+
+func (msg Message1011) SatelliteCount() int {
+	return len(msg.SignalData)
 }
 
 // Extended L1&L2 GLONASS RTK Observables
@@ -150,6 +162,10 @@ func (msg Message1012) Serialize() []byte {
 
 func (msg Message1012) Time() time.Time {
 	return DF034(msg.Epoch, time.Now().UTC())
+}
+
+func (msg Message1012) SatelliteCount() int {
+	return len(msg.SignalData)
 }
 
 // GLONASS Ionospheric Correction Differences

--- a/rtcm3/gps.go
+++ b/rtcm3/gps.go
@@ -38,6 +38,10 @@ func (msg Message1001) Time() time.Time {
 	return DF004(msg.Epoch)
 }
 
+func (msg Message1001) SatelliteCount() int {
+	return len(msg.SatelliteData)
+}
+
 // Extended L1-Only GPS RTK Observables
 type Message1002 struct {
 	AbstractMessage
@@ -70,6 +74,10 @@ func (msg Message1002) Serialize() []byte {
 
 func (msg Message1002) Time() time.Time {
 	return DF004(msg.Epoch)
+}
+
+func (msg Message1002) SatelliteCount() int {
+	return len(msg.SatelliteData)
 }
 
 // L1&L2 GPS RTK Observables
@@ -106,6 +114,10 @@ func (msg Message1003) Serialize() []byte {
 
 func (msg Message1003) Time() time.Time {
 	return DF004(msg.Epoch)
+}
+
+func (msg Message1003) SatelliteCount() int {
+	return len(msg.SatelliteData)
 }
 
 // Extended L1&L2 GPS RTK Observables
@@ -145,6 +157,10 @@ func (msg Message1004) Serialize() []byte {
 
 func (msg Message1004) Time() time.Time {
 	return DF004(msg.Epoch)
+}
+
+func (msg Message1004) SatelliteCount() int {
+	return len(msg.SatelliteData)
 }
 
 // Network Auxiliary Station Data Message

--- a/rtcm3/message.go
+++ b/rtcm3/message.go
@@ -21,6 +21,7 @@ type Observation interface {
 	Message
 	// Epoch at which the data was observed
 	Time() time.Time
+	SatelliteCount() int
 }
 
 // AbstractMessage is used to factor out the MessageNumber attribute

--- a/rtcm3/msm.go
+++ b/rtcm3/msm.go
@@ -28,6 +28,10 @@ func (header MsmHeader) Number() int {
 	return int(header.MessageNumber)
 }
 
+func (header MsmHeader) SatelliteCount() int {
+	return bits.OnesCount(uint(header.SatelliteMask))
+}
+
 func DeserializeMsmHeader(r *iobit.Reader) (header MsmHeader) {
 	header = MsmHeader{
 		MessageNumber:          r.Uint16(12),


### PR DESCRIPTION
Currently anything with the Time method will satisfy the Observation interface, meaning SSR messages match for example.