### PR TITLE
Add test for GPS leap second bondary

### DIFF
--- a/rtcm3/time.go
+++ b/rtcm3/time.go
@@ -9,7 +9,12 @@ import (
 // GPS Epoch Time (TOW)
 func DF004(e uint32) time.Time {
 	now := time.Now().UTC()
-	sow := now.Truncate(time.Hour*24).AddDate(0, 0, -int(now.Weekday()))
+	return DF004Time(e, now)
+}
+
+func DF004Time(e uint32, start time.Time) time.Time {
+	start = start.Add(rtcm.GpsLeapSeconds()) // UTC to GPS time
+	sow := start.Truncate(time.Hour*24).AddDate(0, 0, -int(start.Weekday()))
 	tow := time.Duration(e) * time.Millisecond
 	return sow.Add(-(rtcm.GpsLeapSeconds())).Add(tow)
 }


### PR DESCRIPTION
```
$ go test time_test.go -v -run TestDF004
=== RUN   TestDF004
--- FAIL: TestDF004 (0.00s)
    time_test.go:35: DF004 time incorrect. Expected 2021-11-13 23:59:48 +0000 UTC, got 2021-11-06 23:59:48 +0000 UTC (604800000ms difference)
=== RUN   TestDF004Works
--- PASS: TestDF004Works (0.00s)
FAIL
FAIL	command-line-arguments	0.002s
FAIL
```

If I uncomment the fix [(add leap seconds before calculating GPS start of week)](https://github.com/go-gnss/rtcm/compare/master...jmettes:fix-leapsecond?expand=1#diff-8ae19e15f0e122a9804b030d5032851e5a3744fd9bcb8fcd30c2aaad2c6f09b2R12)
```
$ go test time_test.go -v -run TestDF004                   
=== RUN   TestDF004
--- PASS: TestDF004 (0.00s)
=== RUN   TestDF004Works
--- PASS: TestDF004Works (0.00s)
PASS
ok  	command-line-arguments	0.001s
```